### PR TITLE
Fix StandardCard layout

### DIFF
--- a/src/components/common/StandardCard.js
+++ b/src/components/common/StandardCard.js
@@ -61,7 +61,7 @@ const StandardCard = ({
   }
 
   return (
-    <Card sx={{ minWidth: 340, flexShrink: 0, display: 'flex', flexDirection: 'column', height: '100%', borderRadius: theme.shape.borderRadius, transition: 'transform 0.3s, box-shadow 0.3s', '&:hover': { transform: 'translateY(-8px)', boxShadow: theme.shadows[10] }, boxShadow: theme.shadows[3], position: 'relative' }}>
+    <Card sx={{ display: 'flex', flexDirection: 'column', height: '100%', borderRadius: theme.shape.borderRadius, transition: 'transform 0.3s, box-shadow 0.3s', '&:hover': { transform: 'translateY(-8px)', boxShadow: theme.shadows[10] }, boxShadow: theme.shadows[3], position: 'relative' }}>
       {showWishlistButton && (
         <IconButton
           aria-label="add to wishlist"
@@ -85,6 +85,7 @@ const StandardCard = ({
         height="220"
         image={imageUrl || "/images/placeholder.jpg"}
         alt={title}
+        sx={{ objectFit: 'cover' }}
       />
       <CardContent sx={{ flexGrow: 1, p: 3 }}>
         <Typography variant="h6" component="h3" fontWeight="600" gutterBottom>{title}</Typography>

--- a/src/components/common/StandardCardSkeleton.js
+++ b/src/components/common/StandardCardSkeleton.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Skeleton, Box } from '@mui/material';
 
 const StandardCardSkeleton = () => (
-  <Box sx={{ minWidth: 340, flexShrink: 0, width: '100%' }}>
+  <Box sx={{ width: '100%' }}>
     <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 3 }} />
     <Box sx={{ pt: 1.5 }}>
       <Skeleton height={30} />


### PR DESCRIPTION
Removed restrictive `minWidth` and `flexShrink` properties to allow `StandardCard` and `StandardCardSkeleton` to adapt dynamically to their parent layout. Added `objectFit: 'cover'` to `CardMedia` to ensure images maintain their aspect ratio properly.

---
*PR created automatically by Jules for task [10377343888383246999](https://jules.google.com/task/10377343888383246999) started by @traveltraildev*